### PR TITLE
Auth token is not reset in the app when signOut

### DIFF
--- a/app/services/session.js
+++ b/app/services/session.js
@@ -127,11 +127,9 @@ export default Ember.Object.extend({
         return false;
       }
 
-      if (!options.beforeSend) {
-        options.beforeSend = function (xhr) {
-          xhr.setRequestHeader('Authorization', authToken);
-        };
-      }
+      options.beforeSend = function (xhr) {
+        xhr.setRequestHeader('Authorization', authToken);
+      };
     });
 
     return true;

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -45,6 +45,9 @@ export default Ember.Object.extend({
   save: function(data) {
     localStorage.setItem(this.localStorageKey(), JSON.stringify(data));
     this.setProperties(data.user);
+    // Do not store auth token key in session, store this info in a single place:
+    // localStorage
+    this.set(this.authTokenKey(), null);
   },
 
   isSignedIn: Ember.computed.notEmpty(config.authTokenKey),

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -118,13 +118,15 @@ export default Ember.Object.extend({
   },
 
   setPrefilter: function() {
-    var authToken = this.get(this.authTokenKey());
-
-    if(Ember.isNone(authToken)) {
-      return false;
-    }
-
     Ember.$.ajaxPrefilter(function(options) {
+      try {
+        var authObj = JSON.parse(localStorage.getItem(this.authTokenKey()));
+        var authToken = authObj['user']['auth_token'];
+      } catch (e) {
+        // ignore json parse error;
+        return false;
+      }
+
       if (!options.beforeSend) {
         options.beforeSend = function (xhr) {
           xhr.setRequestHeader('Authorization', authToken);

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -59,6 +59,7 @@ export default Ember.Object.extend({
           session.set(key, null);
         });
         session.set('isSignedIn', false);
+        session.setPrefilter();
         resolve();
       } catch(e) {
         reject(e);
@@ -124,11 +125,12 @@ export default Ember.Object.extend({
         var authToken = authObj['user']['auth_token'];
       } catch (e) {
         // ignore json parse error;
-        return false;
       }
 
+      // always set authToken no matter the localStorage has the token or not
+      // since we want to sign out and clean the request header
       options.beforeSend = function (xhr) {
-        xhr.setRequestHeader('Authorization', authToken);
+        xhr.setRequestHeader('Authorization', authToken || '');
       };
     });
 


### PR DESCRIPTION
# In this bug fix, we
1. always read localStorage to set the xhr header.
2. store the auth token only in localStorage.
3. set the auth token to null when sign out.
# Questions:
1. We are using functions such as signIn, signOut ... Should we use computed property and get method?
2. Currently we assume auth token will never change, do we need to deal with that? If we do, we need to rewrite isSignedIn to fire a request to server.
3. How do we test this?
